### PR TITLE
作品サムネ画像の読み込み速度改善

### DIFF
--- a/src/app/actions/api/get-related-works.ts
+++ b/src/app/actions/api/get-related-works.ts
@@ -2,10 +2,9 @@
 
 import { malToAnnict } from '@/lib/anime-id'
 import { annictApiClient } from '@/lib/api/annict-rest'
-import type { Work } from '@/lib/api/annict-rest/schema/works'
 import { jikanApiClient } from '@/lib/api/jikan'
 import { auth } from '@/lib/auth'
-import { type WorkWithThumbnail, getValidWorkImage } from '@/lib/images/valid-thumbnail'
+import { getValidWorkImage } from '@/lib/images/valid-thumbnail'
 
 export const getRelatedWorks = async (malId: number) => {
   await auth()
@@ -46,7 +45,7 @@ export const getRelatedWorks = async (malId: number) => {
   }
 
   const relatedWorksWithThumbnail = await Promise.all(
-    relatedAnnictWorks.value.works.map(async (work: Work): Promise<WorkWithThumbnail> => {
+    relatedAnnictWorks.value.works.map(async (work) => {
       const thumbnail = await getValidWorkImage(work)
       return { ...work, thumbnail }
     }),

--- a/src/app/actions/api/get-search-works.ts
+++ b/src/app/actions/api/get-search-works.ts
@@ -39,7 +39,7 @@ const searchWorks = async (
   }
 
   const worksWithThumbnail = await Promise.all(
-    worksResult.value.works.map(async (work: Work): Promise<WorkWithThumbnail> => {
+    worksResult.value.works.map(async (work) => {
       const thumbnail = await getValidWorkImage(work)
       return { ...work, thumbnail }
     }),


### PR DESCRIPTION
<!-- このPRをレビューする際は必ず日本語で記述すること  -->

## issue

resolve #

## description

関連作品や検索結果のサムネイル画像を `reduce` を使った逐次処理から
  `Promise.all` を使った並列取得に変更。
  (対象: `get-related-works.ts`, `get-search-works.ts`)

## screenshots (optional)

https://github.com/user-attachments/assets/858d2812-9252-453c-8f9a-5eede78823d1


